### PR TITLE
chore(formatter): Update formatter to handle plus signs in emails with Google domains

### DIFF
--- a/data-manager-util/build.gradle
+++ b/data-manager-util/build.gradle
@@ -21,7 +21,7 @@ plugins {
 
 group = 'com.google.api-ads'
 description = 'Utilities for working with the Data Manager API'
-version = '0.2.0'
+version = '0.3.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/data-manager-util/src/main/java/com/google/ads/datamanager/util/UserDataFormatter.java
+++ b/data-manager-util/src/main/java/com/google/ads/datamanager/util/UserDataFormatter.java
@@ -146,6 +146,12 @@ public class UserDataFormatter {
       // "Create variations of your email address" at:
       // https://support.google.com/a/users/answer/9282734
 
+      // Removes plus sign (+) and all characters that follow it.
+      int plusIndex = username.indexOf('+');
+      if (plusIndex != -1) {
+        username = username.substring(0, plusIndex);
+      }
+
       // Removes all periods (.).
       username = PERIOD_PATTERN.matcher(username).replaceAll("");
     }

--- a/data-manager-util/src/test/java/com/google/ads/datamanager/util/UserDataFormatterTest.java
+++ b/data-manager-util/src/test/java/com/google/ads/datamanager/util/UserDataFormatterTest.java
@@ -37,6 +37,10 @@ public class UserDataFormatterTest {
         "Case should be normalized in domain",
         "quinny@example.com",
         formatter.formatEmailAddress("QuinnY@EXAMPLE.com"));
+    assertEquals(
+        "Plus sign and everything after should not be stripped from non google emails",
+        "user.name+nyc@example.com",
+        formatter.formatEmailAddress("user.name+NYC@Example.com"));
   }
 
   @Test
@@ -69,6 +73,14 @@ public class UserDataFormatterTest {
     assertEquals(
         "jeffersonloveshiking@googlemail.com",
         formatter.formatEmailAddress("j.e.f..ferson.Loves.hiking@googlemail.com"));
+    assertEquals(
+        "Plus sign and everything after should be stripped from gmail.com address",
+        "janedoe@gmail.com",
+        formatter.formatEmailAddress("Jane.Doe+shopping@gmail.com"));
+    assertEquals(
+        "Plus sign and everything after should be stripped from googlemail.com address",
+        "janedoe@googlemail.com",
+        formatter.formatEmailAddress("Jane.Doe+shopping@googlemail.com"));
   }
 
   @Test

--- a/data-manager-util/src/test/java/com/google/ads/datamanager/util/UserDataFormatterTest.java
+++ b/data-manager-util/src/test/java/com/google/ads/datamanager/util/UserDataFormatterTest.java
@@ -75,12 +75,12 @@ public class UserDataFormatterTest {
         formatter.formatEmailAddress("j.e.f..ferson.Loves.hiking@googlemail.com"));
     assertEquals(
         "Plus sign and everything after should be stripped from gmail.com address",
-        "janedoe@gmail.com",
-        formatter.formatEmailAddress("Jane.Doe+shopping@gmail.com"));
+        "cloudysanfrancisco@gmail.com",
+        formatter.formatEmailAddress("Cloudy.SanFrancisco+shopping@gmail.com"));
     assertEquals(
         "Plus sign and everything after should be stripped from googlemail.com address",
-        "janedoe@googlemail.com",
-        formatter.formatEmailAddress("Jane.Doe+shopping@googlemail.com"));
+        "cloudysanfrancisco@googlemail.com",
+        formatter.formatEmailAddress("Cloudy.SanFrancisco+shopping@googlemail.com"));
   }
 
   @Test


### PR DESCRIPTION
If the email address has the gmail.com or googlemail.com domain, remove the plus sign from the local-part and all characters that follow it.